### PR TITLE
Only require refills once

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -37,7 +37,6 @@ group :development, :test do
   gem "factory_girl_rails"
   gem "pry-byebug"
   gem "pry-rails"
-  gem "refills"
   gem "rspec-rails", "~> 3.5.0.beta4"
 end
 


### PR DESCRIPTION
 Refills is added to the Gemfile after install via the
 `StylesheetBaseGenerator`. If it is also present in the Gemfile
 template then bundler will issue a warning that refills is required
 twice.

 Changes:

  - Remove refills from Gemfile template